### PR TITLE
improve coverage report

### DIFF
--- a/delta-coverage-core/src/main/kotlin/io/github/surpsg/deltacoverage/report/textual/TextualReportFacade.kt
+++ b/delta-coverage-core/src/main/kotlin/io/github/surpsg/deltacoverage/report/textual/TextualReportFacade.kt
@@ -109,14 +109,19 @@ internal object TextualReportFacade {
     )
 
     private fun Double.formatToPercentage(): String {
-        val percents: Double = this * PERCENT_MULTIPLIER
-        val percentsInt = percents.toInt()
-        val pattern = if (percents > percentsInt) {
-            "%.2f%%"
+        return if (this.isNaN()) {
+            "no diff"
         } else {
-            "%.0f%%"
+            val percents: Double = this * PERCENT_MULTIPLIER
+            val percentsInt = percents.toInt()
+            val pattern = if (percents > percentsInt) {
+                "%.2f%%"
+            } else {
+                "%.0f%%"
+            }
+
+            pattern.format(percents)
         }
-        return pattern.format(percents)
     }
 
     private fun String.shrinkClassName(maxLength: Int): String {

--- a/delta-coverage-core/src/test/kotlin/io/github/surpsg/deltacoverage/report/textual/TextualReportFacadeTest.kt
+++ b/delta-coverage-core/src/test/kotlin/io/github/surpsg/deltacoverage/report/textual/TextualReportFacadeTest.kt
@@ -109,17 +109,17 @@ class TextualReportFacadeTest {
 
             // THEN
             val expectedReport = """
-                +--------------+-------+----------+--------+
-                | [any] Delta Coverage Stats               |
-                +--------------+-------+----------+--------+
-                | Class        | Lines | Branches | Instr. |
-                +--------------+-------+----------+--------+
-                | class12      | NaN%  |          | NaN%   |
-                +--------------+-------+----------+--------+
-                | Total        | NaN%  |          | NaN%   |
-                +--------------+-------+----------+--------+
-                | Min expected |       |          |        |
-                +--------------+-------+----------+--------+
+                +--------------+---------+----------+---------+
+                | [any] Delta Coverage Stats                  |
+                +--------------+---------+----------+---------+
+                | Class        | Lines   | Branches | Instr.  |
+                +--------------+---------+----------+---------+
+                | class12      | no diff |          | no diff |
+                +--------------+---------+----------+---------+
+                | Total        | no diff |          | no diff |
+                +--------------+---------+----------+---------+
+                | Min expected |         |          |         |
+                +--------------+---------+----------+---------+
                 
             """.trimIndent()
             stream.toString() shouldBe expectedReport
@@ -229,11 +229,11 @@ class TextualReportFacadeTest {
 
             // THEN
             val expectedReport = """
-            | Class        | Lines | Branches | Instr. |
-            |--------------|-------|----------|--------|
-            | class1       | NaN%  |          | NaN%   |
-            | Total        | NaN%  |          | NaN%   |
-            | Min expected |       |          |        |
+            | Class        | Lines   | Branches | Instr.  |
+            |--------------|---------|----------|---------|
+            | class1       | no diff |          | no diff |
+            | Total        | no diff |          | no diff |
+            | Min expected |         |          |         |
             
         """.trimIndent()
             stream.toString() shouldBe expectedReport

--- a/gradle/deps.versions.toml
+++ b/gradle/deps.versions.toml
@@ -12,7 +12,7 @@ mockkVer = "1.13.13"
 kotestVer = "5.9.1"
 jimfsVer = "1.3.0"
 
-deltaCoverageVer = "3.0.0-RC2.580"
+deltaCoverageVer = "3.0.1"
 
 [libraries]
 # Kotlin


### PR DESCRIPTION
previously, when no diff present, the report contained the following value in the table:
```
  +--------------+-------+----------+--------+
  | class12      | NaN%  |          | NaN%   |
  +--------------+-------+----------+--------+
```
this commit changes value to be slightly more descriptive:
```
  +--------------+---------+----------+---------+
  | class12      | no diff |          | no diff |
  +--------------+---------+----------+---------+
```
such that the user don't think some error happened in the delta-coverage itself, but this is an expected case.