### PR TITLE
Fix delta coverage task dependencies on classes task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Delta-Coverage Gradle plugin Changelog
 
+## 3.6.1
+
+### Fixed
+- Fixed task dependencies of delta coverage tasks. Delta coverage tasks now correctly depend on the `classes` task 
+  so compiled classes are available before coverage is computed.
+
 ## 3.6.0
 
 ### New features

--- a/delta-coverage-gradle/src/main/kotlin/io/github/surpsg/deltacoverage/gradle/DeltaCoveragePlugin.kt
+++ b/delta-coverage-gradle/src/main/kotlin/io/github/surpsg/deltacoverage/gradle/DeltaCoveragePlugin.kt
@@ -9,7 +9,6 @@ import io.github.surpsg.deltacoverage.gradle.utils.deltaCoverageConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.TaskProvider
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -113,9 +112,6 @@ open class DeltaCoveragePlugin : Plugin<Project> {
         const val DELTA_COVERAGE_TASK = "deltaCoverage"
         const val GIT_DIFF_TASK = "gitDiff"
 
-        val DELTA_TASK_DEPENDENCIES = setOf(
-            JavaPlugin.CLASSES_TASK_NAME,
-        )
         val log: Logger = LoggerFactory.getLogger(DeltaCoveragePlugin::class.java)
     }
 }

--- a/delta-coverage-gradle/src/main/kotlin/io/github/surpsg/deltacoverage/gradle/task/DeltaCoverageTaskConfigurer.kt
+++ b/delta-coverage-gradle/src/main/kotlin/io/github/surpsg/deltacoverage/gradle/task/DeltaCoverageTaskConfigurer.kt
@@ -2,13 +2,13 @@ package io.github.surpsg.deltacoverage.gradle.task
 
 import io.github.gwkit.coverjet.gradle.task.CovAgentProperties
 import io.github.surpsg.deltacoverage.gradle.DeltaCoverageConfiguration
-import io.github.surpsg.deltacoverage.gradle.DeltaCoveragePlugin.Companion.DELTA_TASK_DEPENDENCIES
 import io.github.surpsg.deltacoverage.gradle.DeltaCoveragePlugin.Companion.log
 import io.github.surpsg.deltacoverage.gradle.sources.SourceType
 import io.github.surpsg.deltacoverage.gradle.sources.SourcesResolver
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.testing.Test
 
@@ -16,38 +16,34 @@ internal object DeltaCoverageTaskConfigurer {
 
     const val AGGREGATED_REPORT_VIEW_NAME = "aggregated"
 
+    private val MUST_RUN_AFTER_DEPS: List<Class<out Task>> = listOf(
+        Test::class.java,
+        CovAgentProperties::class.java,
+    )
+
     fun configure(
         view: String,
         deltaCoverageConfig: DeltaCoverageConfiguration,
         deltaCoverageTask: DeltaCoverageTask,
     ) = with(deltaCoverageTask) {
+        log.info("Configuring {}...", deltaCoverageTask)
         viewName.set(view)
         deltaCoverageConfigProperty.set(deltaCoverageConfig)
         configureDependencies()
         applySourcesInputs(view, deltaCoverageConfig)
     }
 
-    private fun DeltaCoverageTask.configureDependencies() {
+    private fun DeltaCoverageTask.configureDependencies() = project.allprojects { proj ->
+        val projectTasks = proj.tasks
         val deltaCoverageTask: DeltaCoverageTask = this
-        project.allprojects { proj ->
-            proj.tasks.configureEach { task ->
-                deltaCoverageTask.configureDependencyOn(task)
+        proj.pluginManager.withPlugin("java") {
+            deltaCoverageTask.dependsOn(projectTasks.named(JavaPlugin.CLASSES_TASK_NAME))
+            log.info("Configured task {} to depends on {}", deltaCoverageTask, JavaPlugin.CLASSES_TASK_NAME)
+            MUST_RUN_AFTER_DEPS.forEach { taskType ->
+                deltaCoverageTask.mustRunAfter(projectTasks.withType(taskType))
             }
+            log.info("Configured task {} to must run after: {}", deltaCoverageTask, MUST_RUN_AFTER_DEPS)
         }
-    }
-
-    private fun DeltaCoverageTask.configureDependencyOn(task: Task) = when {
-        task.name in DELTA_TASK_DEPENDENCIES -> {
-            log.info("Configuring {} to depend on {}", this, task)
-            dependsOn(task)
-        }
-
-        task is Test || task is CovAgentProperties -> {
-            log.info("Configuring {} to run after {}", this, task)
-            mustRunAfter(task)
-        }
-
-        else -> this
     }
 
     private fun DeltaCoverageTask.applySourcesInputs(

--- a/delta-coverage-gradle/src/test/kotlin/io/github/surpsg/deltacoverage/gradle/task/DeltaCoverageTaskTest.kt
+++ b/delta-coverage-gradle/src/test/kotlin/io/github/surpsg/deltacoverage/gradle/task/DeltaCoverageTaskTest.kt
@@ -4,9 +4,13 @@ import io.github.surpsg.deltacoverage.gradle.DeltaCoverageConfiguration
 import io.github.surpsg.deltacoverage.gradle.unittest.applyDeltaCoveragePlugin
 import io.github.surpsg.deltacoverage.gradle.unittest.testJavaProject
 import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.file.shouldExist
 import io.kotest.matchers.file.shouldNotExist
+import org.gradle.api.Task
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.provider.Provider
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -59,6 +63,38 @@ class DeltaCoverageTaskTest {
                 actualSummaryFile.shouldExist()
             }
         }
+    }
+
+    @Test
+    fun `delta coverage task should depend on classes`() {
+        // GIVEN
+        val project: ProjectInternal = testJavaProject {
+            applyDeltaCoveragePlugin()
+
+            val diffFile = tempDir.resolve("111").apply {
+                createNewFile()
+            }
+
+            extensions.configure(DeltaCoverageConfiguration::class.java) { config ->
+                with(config) {
+                    diffSource { source ->
+                        source.file.set(diffFile.absolutePath)
+                    }
+                }
+            }
+        }
+
+        // WHEN
+        val deltaCoverageTasks = project.tasks.withType(DeltaCoverageTask::class.java).toList()
+
+        // THEN
+        println(deltaCoverageTasks)
+        val dependsOnTasks: List<String?> = deltaCoverageTasks
+            .flatMap { it.dependsOn }
+            .filterIsInstance<Provider<out Task>>()
+            .map { it.get().name }
+
+        dependsOnTasks shouldContain JavaPlugin.CLASSES_TASK_NAME
     }
 
     @Nested

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.6.0
+version=3.6.1
 group=io.github.gw-kit
 org.gradle.parallel=true
 kotlin.code.style=official


### PR DESCRIPTION
Delta coverage tasks now explicitly depend on the java plugin's classes task and mustRunAfter Test/CovAgentProperties tasks, replacing the per-task name-based configureEach lookup. Bump version to 3.6.1.